### PR TITLE
Add support for 252

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "2.1.21"
@@ -34,12 +36,12 @@ tasks {
         targetCompatibility = "17"
     }
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-        kotlinOptions.jvmTarget = "17"
+        compilerOptions.jvmTarget = JvmTarget.JVM_17
     }
 
     patchPluginXml {
         sinceBuild.set("242")
-        untilBuild.set("245.*")
+        untilBuild.set("252.*")
     }
 
     signPlugin {


### PR DESCRIPTION
I'm unsure why "until" was 245, as it doesn't seem to be a valid version number for IJ.

Also, I was trying to verify the plugin, but stumbled on this error https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/1965
